### PR TITLE
remove turbolinks

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,11 +11,9 @@
 // about supported directives.
 //
 //= require jquery
-//= require jquery.turbolinks
 //= require jquery_ujs
 //= require best_in_place
 //= require foundation
-//= require turbolinks
 //= require fastclick
 //= require_tree .
 


### PR DESCRIPTION
turbolinks caused pickups quantity to be increase by 2 if coming from the /pickups screen.
Turbolinks sucks, so no need for it anyway